### PR TITLE
fix(schemas): add developer_id property sent from konnect to incoming payload schemas

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -171,6 +171,9 @@ components:
         organization_id:
           type: string
           format: uuid
+        developer_id:
+          type: string
+          format: uuid
       required:
       - event_type
       - client_id
@@ -179,6 +182,7 @@ components:
       - application_description
       - portal_id
       - organization_id
+      - developer_id
     EventHookUpdateApplication:
       additionalProperties: false
       properties:
@@ -267,6 +271,9 @@ components:
         organization_id:
           type: string
           format: uuid
+        developer_id:
+          type: string
+          format: uuid
       required:
       - redirect_uris
       - client_name
@@ -275,6 +282,7 @@ components:
       - application_description
       - portal_id
       - organization_id
+      - developer_id
     ApplicationResponse:
       type: object
       additionalProperties: false

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -28,7 +28,8 @@ describe('dcr handlers', () => {
         token_endpoint_auth_method: 'client_secret_post',
         application_description: 'disisatest',
         portal_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2705',
-        organization_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2706'
+        organization_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2706',
+        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707'
       }
 
       jest.spyOn(mockAxios, 'post').mockResolvedValueOnce({
@@ -76,7 +77,8 @@ describe('dcr handlers', () => {
         token_endpoint_auth_method: 'client_secret_post',
         application_description: 'disisatest',
         portal_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2705',
-        organization_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2706'
+        organization_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2706',
+        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707'
       }
 
       const resp = await app.inject({
@@ -104,7 +106,8 @@ describe('dcr handlers', () => {
         token_endpoint_auth_method: 'client_secret_post',
         application_description: 'disisatest',
         portal_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2705',
-        organization_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2706'
+        organization_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2706',
+        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707'
       }
 
       const resp = await app.inject({
@@ -224,7 +227,8 @@ describe('dcr handlers', () => {
         application_name: 'name',
         application_description: 'description',
         portal_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
-        organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8'
+        organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
+        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707'
       }
 
       const resp = await app.inject({
@@ -250,7 +254,8 @@ describe('dcr handlers', () => {
         application_name: 'name',
         application_description: 'description',
         portal_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
-        organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8'
+        organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
+        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707'
       }
 
       const resp = await app.inject({
@@ -277,7 +282,8 @@ describe('dcr handlers', () => {
         application_name: 'name',
         application_description: 'description',
         portal_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
-        organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8'
+        organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
+        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707'
       }
 
       const resp = await app.inject({
@@ -302,7 +308,8 @@ describe('dcr handlers', () => {
         application_name: 'name',
         application_description: 'description',
         portal_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
-        organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8'
+        organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
+        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707'
       }
 
       const resp = await app.inject({

--- a/src/schemas/ApplicationPayload.ts
+++ b/src/schemas/ApplicationPayload.ts
@@ -6,6 +6,7 @@ export interface ApplicationPayload {
   application_description: string
   portal_id: string
   organization_id: string
+  developer_id: string
 }
 
 export const ApplicationPayloadSchema = {

--- a/src/schemas/EventHook.ts
+++ b/src/schemas/EventHook.ts
@@ -15,6 +15,7 @@ export type EventHook = {
   application_description: string
   portal_id: string
   organization_id: string
+  developer_id: string
 } & (
   | {
     event_type: 'update_application'
@@ -64,6 +65,9 @@ export const EventHookSchema = {
     organization_id: {
       type: 'string'
     },
+    developer_id: {
+      type: 'string'
+    },
     api_product_version_id: {
       type: 'string'
     },
@@ -80,7 +84,8 @@ export const EventHookSchema = {
       'application_name',
       'application_description',
       'portal_id',
-      'organization_id'
+      'organization_id',
+      'developer_id'
     ],
   allOf: [
     {


### PR DESCRIPTION
The schemas was out of sync with the implementation, resulting in dropped `developer_id` property.