### PR TITLE
fix(spec): misleading applicationId [TDX-3923]

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -24,9 +24,9 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
-  /{applicationId}:
+  /{clientId}:
     parameters:
-    - $ref: '#/components/parameters/applicationId'
+    - $ref: '#/components/parameters/clientId'
     delete:
       summary: Delete application
       description: Deletes the application in the IDP
@@ -37,9 +37,9 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
-  /{applicationId}/new-secret:
+  /{clientId}/new-secret:
     parameters:
-    - $ref: '#/components/parameters/applicationId'
+    - $ref: '#/components/parameters/clientId'
     post:
       summary: rotates client_secret
       description: |
@@ -51,9 +51,9 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
-  /{applicationId}/event-hook:
+  /{clientId}/event-hook:
     parameters:
-    - $ref: '#/components/parameters/applicationId'
+    - $ref: '#/components/parameters/clientId'
     post:
       summary: Application lifecycle webhook
       description: |
@@ -72,11 +72,13 @@ paths:
           $ref: '#/components/responses/Unauthorized'
 components:
   parameters:
-    applicationId:
-      name: applicationId
+    clientId:
+      name: clientId
       in: path
       required: true
-      description: lorem ipsum
+      description: |
+        ID of the application in the IDP. This is the ID used accross
+        the system and is unique. The format can vary between IDPs.
       schema:
         type: string
   requestBodies:

--- a/src/handlers/handler.ts
+++ b/src/handlers/handler.ts
@@ -63,13 +63,13 @@ export function DCRHandlers (fastify: FastifyInstance, _: RegisterOptions, next:
   })
 
   fastify.route({
-    url: '/:application_id',
+    url: '/:client_id',
     method: 'DELETE',
-    handler: async function (request: FastifyRequest<{ Params: { application_id: string } }>, reply: FastifyReply): Promise<FastifyReply> {
+    handler: async function (request: FastifyRequest<{ Params: { client_id: string } }>, reply: FastifyReply): Promise<FastifyReply> {
       const headers = getHeaders(fastify.config.OKTA_API_TOKEN)
 
       await fastify.httpClient.delete(
-        `oauth2/v1/clients/${request.params.application_id}`,
+        `oauth2/v1/clients/${request.params.client_id}`,
         { headers }
       )
       return reply.code(204).send()
@@ -77,30 +77,30 @@ export function DCRHandlers (fastify: FastifyInstance, _: RegisterOptions, next:
   })
 
   fastify.route({
-    url: '/:application_id/new-secret',
+    url: '/:client_id/new-secret',
     method: 'POST',
-    handler: async function (request: FastifyRequest<{ Params: { application_id: string } }>, reply: FastifyReply): Promise<FastifyReply> {
+    handler: async function (request: FastifyRequest<{ Params: { client_id: string } }>, reply: FastifyReply): Promise<FastifyReply> {
       const headers = getHeaders(fastify.config.OKTA_API_TOKEN)
       const response = await fastify.httpClient.post(
-        `oauth2/v1/clients/${request.params.application_id}/lifecycle/newSecret`,
+        `oauth2/v1/clients/${request.params.client_id}/lifecycle/newSecret`,
         {},
         { headers }
       )
 
       return reply.code(200).send({
-        client_id: request.params.application_id,
+        client_id: request.params.client_id,
         client_secret: response.data.client_secret
       })
     }
   })
 
   fastify.route({
-    url: '/:application_id/event-hook',
+    url: '/:client_id/event-hook',
     method: 'POST',
     schema: {
       body: EventHookSchema
     },
-    handler: async function (request: FastifyRequest<{ Params: { application_id: string }, Body: { EventHook } }>, reply: FastifyReply): Promise<FastifyReply> {
+    handler: async function (request: FastifyRequest<{ Params: { client_id: string }, Body: { EventHook } }>, reply: FastifyReply): Promise<FastifyReply> {
       return reply.code(200).send()
     }
   })


### PR DESCRIPTION
Spec was describing the `clientId` from the IDP as `applicationId` which is a konnect concept; it was misleading for customers. This PR addresses the fix on the spec and on the example handlers