### PR TITLE
feat(spec): include redirect_uris in application update schema

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -191,8 +191,13 @@ components:
         event_type:
           type: string
           enum: [update_application]
+        redirect_uris:
+          type: array
+          items:
+            type: string
       required:
       - event_type
+      - redirect_uris
     EventHookAddRegistration:
       additionalProperties: false
       properties:

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -228,7 +228,10 @@ describe('dcr handlers', () => {
         application_description: 'description',
         portal_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
         organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
-        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707'
+        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707',
+        redirect_uris: [
+          'https://example.com'
+        ]
       }
 
       const resp = await app.inject({
@@ -309,7 +312,10 @@ describe('dcr handlers', () => {
         application_description: 'description',
         portal_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
         organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
-        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707'
+        developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707',
+        redirect_uris: [
+          'https://example.com'
+        ]
       }
 
       const resp = await app.inject({

--- a/src/schemas/EventHook.ts
+++ b/src/schemas/EventHook.ts
@@ -18,6 +18,7 @@ export type EventHook = {
   developer_id: string
 } & (
   | {
+    redirect_uris: string[]
     event_type: 'update_application'
   }
   | {
@@ -94,9 +95,18 @@ export const EventHookSchema = {
           properties: {
             event_type: {
               const: 'update_application'
+            },
+            redirect_uris: {
+              type: 'array',
+              items: {
+                type: 'string'
+              }
             }
           },
-          required: ['event_type']
+          required: [
+            'event_type',
+            'redirect_uris'
+          ]
         },
         {
           properties: {


### PR DESCRIPTION
The current `redirect_uris` for the application should be sent in the application update event. They can be the same as the previous values if unchanged, or the new values if they were updated.