### PR TITLE
feat(dcr): adds endpoints for multi secrets

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,29 @@
+# GitHub Copilot Instructions
+
+**Primary instructions:** Read and follow [AGENTS.md](../AGENTS.md) completely.
+
+## Critical Boundaries (duplicated for safety)
+
+- Never modify files in node_modules/ or dist/
+- Do not commit .env files or API keys (KONG_API_TOKENS, OKTA_API_TOKEN, OKTA_DOMAIN must be environment variables)
+- Follow branch naming conventions: feat/, fix/, test/, refactor/, style/, docs/, ci/
+- Always run 'yarn test' and 'yarn lint' before creating a PR
+- PRs must be created as drafts for human review
+- Comply with CODE_OF_CONDUCT.md standards
+- This is a reference implementation - do not treat as production-ready code
+- Use Yarn 1.22.x (not npm or other package managers)
+- Node.js version must be >=20 (specified in .nvmrc as v20.10.0)
+- Maintain ESLint standard-with-typescript config (2-space indentation, single quotes, Unix line endings)
+- All environment variables must be set before running (KONG_API_TOKENS, OKTA_DOMAIN, OKTA_API_TOKEN)
+- AWS Lambda deployment only occurs on main branch via CI/CD pipeline
+
+## Quick Reference
+
+Build: `yarn build`
+Test: `yarn test`
+Lint: `yarn lint`
+
+
+## When to Stay Silent
+
+If you're uncertain whether something is an issue, don't comment. False positives create noise and reduce trust in the review process.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "SSWS"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Kong konnect-portal-dcr-handler
+
+## Overview
+An open-source HTTP DCR (Dynamic Client Registration) bridge that acts as a proxy between Konnect Dev Portal and third-party Identity Providers (specifically Okta), translating DCR API calls and managing OAuth2 client lifecycle. This is a reference implementation designed for AWS Lambda deployment, not production use.
+
+## Tech Stack
+- **Language:** TypeScript 5.x (Node.js 20.10.0) (Fastify 4.x)
+- **Database:** None
+- **Testing:** Jest with ts-jest (run with 'yarn test')
+- **CI:** GitHub Actions
+
+## Build & Test Commands
+```bash
+yarn build           # Build the project
+yarn test            # Run tests
+yarn lint            # Run linter
+yarn lint:fix        # Format code
+tsc --noEmit         # Type check
+```
+
+## Architecture
+- `src/` - Main application source code
+- `src/handlers/` - Fastify route handlers implementing DCR API endpoints (POST /, DELETE /:client_id, POST /:client_id/new-secret, POST /:client_id/event-hook)
+- `src/schemas/` - Request/response validation schemas (ApplicationPayload, ApplicationResponse, EventHook)
+- `openapi/` - OpenAPI specification for the HTTP DCR API
+- `dist/` - TypeScript compilation output (gitignored)
+
+## Boundaries
+- Never modify files in node_modules/ or dist/
+- Do not commit .env files or API keys (KONG_API_TOKENS, OKTA_API_TOKEN, OKTA_DOMAIN must be environment variables)
+- Follow branch naming conventions: feat/, fix/, test/, refactor/, style/, docs/, ci/
+- Always run 'yarn test' and 'yarn lint' before creating a PR
+- PRs must be created as drafts for human review
+- Comply with CODE_OF_CONDUCT.md standards
+- This is a reference implementation - do not treat as production-ready code
+- Use Yarn 1.22.x (not npm or other package managers)
+- Node.js version must be >=20 (specified in .nvmrc as v20.10.0)
+- Maintain ESLint standard-with-typescript config (2-space indentation, single quotes, Unix line endings)
+- All environment variables must be set before running (KONG_API_TOKENS, OKTA_DOMAIN, OKTA_API_TOKEN)
+- AWS Lambda deployment only occurs on main branch via CI/CD pipeline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+@AGENTS.md
+
+## Critical Boundaries (duplicated for safety)
+
+- Never modify files in node_modules/ or dist/
+- Do not commit .env files or API keys (KONG_API_TOKENS, OKTA_API_TOKEN, OKTA_DOMAIN must be environment variables)
+- Follow branch naming conventions: feat/, fix/, test/, refactor/, style/, docs/, ci/
+- Always run 'yarn test' and 'yarn lint' before creating a PR
+- PRs must be created as drafts for human review
+- Comply with CODE_OF_CONDUCT.md standards
+- This is a reference implementation - do not treat as production-ready code
+- Use Yarn 1.22.x (not npm or other package managers)
+- Node.js version must be >=20 (specified in .nvmrc as v20.10.0)
+- Maintain ESLint standard-with-typescript config (2-space indentation, single quotes, Unix line endings)
+- All environment variables must be set before running (KONG_API_TOKENS, OKTA_DOMAIN, OKTA_API_TOKEN)
+- AWS Lambda deployment only occurs on main branch via CI/CD pipeline
+
+## Quick Reference
+
+Build: `yarn build`
+Test: `yarn test`
+Lint: `yarn lint`

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -70,6 +70,51 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /{clientId}/secrets:
+    parameters:
+    - $ref: '#/components/parameters/clientId'
+    get:
+      summary: List client secrets
+      description: |
+        Lists all client secrets for the application. Returns metadata only,
+        not the actual secret values (security best practice).
+      responses:
+        '200':
+          $ref: '#/components/responses/SecretList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      summary: Create a new client secret
+      description: |
+        Creates an additional client secret for the application.
+        The secret value is only returned in this response (one-time).
+        Note: Some IDPs limit the number of secrets (e.g., Okta allows max 2).
+      responses:
+        '201':
+          $ref: '#/components/responses/NewSecretWithId'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /{clientId}/secrets/{secretId}:
+    parameters:
+    - $ref: '#/components/parameters/clientId'
+    - $ref: '#/components/parameters/secretId'
+    delete:
+      summary: Delete a specific client secret
+      description: |
+        Deletes a specific client secret by ID. The handler will
+        automatically deactivate the secret before deletion if required
+        by the IDP (e.g., Okta).
+      responses:
+        '204':
+          description: Secret successfully deleted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 components:
   parameters:
     clientId:
@@ -79,6 +124,15 @@ components:
       description: |
         ID of the application in the IDP. This is the ID used accross
         the system and is unique. The format can vary between IDPs.
+      schema:
+        type: string
+    secretId:
+      name: secretId
+      in: path
+      required: true
+      description: |
+        ID of the specific secret in the IDP. This is the IDP-specific
+        identifier returned when listing secrets.
       schema:
         type: string
   requestBodies:
@@ -119,6 +173,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/SecretResponse'
+    SecretList:
+      description: List of client secrets (metadata only)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SecretListResponse'
+    NewSecretWithId:
+      description: Newly created secret with ID
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SecretWithIdResponse'
   schemas:
     ClientId:
       type: string
@@ -339,6 +405,71 @@ components:
         client_secret:
           $ref: '#/components/schemas/ClientSecret'
       required:
+      - client_id
+      - client_secret
+    SecretId:
+      type: string
+      description: |
+        IDP-specific identifier for the secret. Format varies by IDP.
+      example: "ocsXXXXXXXXXXX"
+    SecretStatus:
+      type: string
+      enum:
+      - ACTIVE
+      - INACTIVE
+      description: Status of the client secret
+    SecretMetadata:
+      type: object
+      additionalProperties: false
+      properties:
+        secret_id:
+          $ref: '#/components/schemas/SecretId'
+        client_id:
+          $ref: '#/components/schemas/ClientId'
+        status:
+          $ref: '#/components/schemas/SecretStatus'
+        created_at:
+          type: string
+          format: date-time
+          description: When the secret was created
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the secret expires (if applicable)
+      required:
+      - secret_id
+      - client_id
+      - status
+    SecretListResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        secrets:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecretMetadata'
+      required:
+      - secrets
+    SecretWithIdResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        secret_id:
+          $ref: '#/components/schemas/SecretId'
+        client_id:
+          $ref: '#/components/schemas/ClientId'
+        client_secret:
+          $ref: '#/components/schemas/ClientSecret'
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - secret_id
       - client_id
       - client_secret
   securitySchemes:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -76,6 +76,8 @@ paths:
     get:
       summary: List client secrets
       description: |
+        **BETA: This endpoint is in development and may change before GA.**
+
         Lists all client secrets for the application. Returns metadata only,
         not the actual secret values (security best practice).
       responses:
@@ -88,6 +90,8 @@ paths:
     post:
       summary: Create a new client secret
       description: |
+        **BETA: This endpoint is in development and may change before GA.**
+
         Creates an additional client secret for the application.
         The secret value is only returned in this response (one-time).
         Note: Some IDPs limit the number of secrets (e.g., Okta allows max 2).
@@ -105,6 +109,8 @@ paths:
     delete:
       summary: Delete a specific client secret
       description: |
+        **BETA: This endpoint is in development and may change before GA.**
+
         Deletes a specific client secret by ID. The handler will
         automatically deactivate the secret before deletion if required
         by the IDP (e.g., Okta).

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -375,4 +375,165 @@ describe('dcr handlers', () => {
       expect(parsedBody.error_description[0].params.missingProperty).toBe('event_type')
     })
   })
+
+  describe('List Secrets', () => {
+    it('succeed', async () => {
+      jest.spyOn(mockAxios, 'get').mockResolvedValueOnce({
+        data: [
+          {
+            id: 'ocs123456789',
+            status: 'ACTIVE',
+            created: '2024-01-01T00:00:00Z',
+            expiresAt: null
+          },
+          {
+            id: 'ocs987654321',
+            status: 'INACTIVE',
+            created: '2024-01-02T00:00:00Z',
+            expiresAt: '2025-01-02T00:00:00Z'
+          }
+        ],
+        status: 200
+      } as any)
+
+      const resp = await app.inject({
+        method: 'GET',
+        url: '/someClientId/secrets',
+        headers: {
+          'X-API-KEY': app.config.KONG_API_TOKENS[0]
+        }
+      })
+
+      expect(resp.statusCode).toEqual(200)
+      expect(resp.json()).toEqual({
+        secrets: [
+          {
+            secret_id: 'ocs123456789',
+            client_id: 'someClientId',
+            status: 'ACTIVE',
+            created_at: '2024-01-01T00:00:00Z',
+            expires_at: null
+          },
+          {
+            secret_id: 'ocs987654321',
+            client_id: 'someClientId',
+            status: 'INACTIVE',
+            created_at: '2024-01-02T00:00:00Z',
+            expires_at: '2025-01-02T00:00:00Z'
+          }
+        ]
+      })
+      expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails because of a wrong API token', async () => {
+      const resp = await app.inject({
+        method: 'GET',
+        url: '/someClientId/secrets',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      })
+
+      expect(resp.statusCode).toEqual(401)
+      expect(resp.body).toEqual(JSON.stringify({ error: 'Wrong API-Key', error_description: 'wrong x-api-key header' }))
+      expect(mockAxios.get).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Create Secret', () => {
+    it('succeed', async () => {
+      jest.spyOn(mockAxios, 'post').mockResolvedValueOnce({
+        data: {
+          id: 'ocs123456789',
+          client_secret: 'newSecretValue123',
+          created: '2024-01-01T00:00:00Z',
+          expiresAt: null
+        },
+        status: 201
+      } as any)
+
+      const resp = await app.inject({
+        method: 'POST',
+        url: '/someClientId/secrets',
+        headers: {
+          'X-API-KEY': app.config.KONG_API_TOKENS[0]
+        }
+      })
+
+      expect(resp.statusCode).toEqual(201)
+      expect(resp.json()).toEqual({
+        secret_id: 'ocs123456789',
+        client_id: 'someClientId',
+        client_secret: 'newSecretValue123',
+        created_at: '2024-01-01T00:00:00Z',
+        expires_at: null
+      })
+      expect(mockAxios.post).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails because of a wrong API token', async () => {
+      const resp = await app.inject({
+        method: 'POST',
+        url: '/someClientId/secrets'
+      })
+
+      expect(resp.statusCode).toEqual(401)
+      expect(resp.body).toEqual(JSON.stringify({ error: 'Wrong API-Key', error_description: 'wrong x-api-key header' }))
+      expect(mockAxios.post).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Delete Secret', () => {
+    it('succeed with deactivation', async () => {
+      jest.spyOn(mockAxios, 'post').mockResolvedValueOnce({ status: 200 } as any)
+      jest.spyOn(mockAxios, 'delete').mockResolvedValueOnce({ status: 204 } as any)
+
+      const resp = await app.inject({
+        method: 'DELETE',
+        url: '/someClientId/secrets/someSecretId',
+        headers: {
+          'X-API-KEY': app.config.KONG_API_TOKENS[0]
+        }
+      })
+
+      expect(resp.statusCode).toEqual(204)
+      expect(mockAxios.post).toHaveBeenCalledTimes(1)
+      expect(mockAxios.delete).toHaveBeenCalledTimes(1)
+    })
+
+    it('succeed when already inactive', async () => {
+      jest.spyOn(mockAxios, 'post').mockRejectedValueOnce({
+        response: { status: 400 }
+      })
+      jest.spyOn(mockAxios, 'delete').mockResolvedValueOnce({ status: 204 } as any)
+
+      const resp = await app.inject({
+        method: 'DELETE',
+        url: '/someClientId/secrets/someSecretId',
+        headers: {
+          'X-API-KEY': app.config.KONG_API_TOKENS[0]
+        }
+      })
+
+      expect(resp.statusCode).toEqual(204)
+      expect(mockAxios.post).toHaveBeenCalledTimes(1)
+      expect(mockAxios.delete).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails because of a wrong API token', async () => {
+      const resp = await app.inject({
+        method: 'DELETE',
+        url: '/someClientId/secrets/someSecretId',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      })
+
+      expect(resp.statusCode).toEqual(401)
+      expect(resp.body).toEqual(JSON.stringify({ error: 'Wrong API-Key', error_description: 'wrong x-api-key header' }))
+      expect(mockAxios.post).not.toHaveBeenCalled()
+      expect(mockAxios.delete).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/handlers/handler.ts
+++ b/src/handlers/handler.ts
@@ -105,6 +105,95 @@ export function DCRHandlers (fastify: FastifyInstance, _: RegisterOptions, next:
     }
   })
 
+  // GET /:client_id/secrets - List all secrets
+  fastify.route({
+    url: '/:client_id/secrets',
+    method: 'GET',
+    handler: async function (
+      request: FastifyRequest<{ Params: { client_id: string } }>,
+      reply: FastifyReply
+    ): Promise<FastifyReply> {
+      const headers = getHeaders(fastify.config.OKTA_API_TOKEN)
+
+      const response = await fastify.httpClient.get(
+        `oauth2/v1/clients/${request.params.client_id}/credentials/secrets`,
+        { headers }
+      )
+
+      const secrets = response.data.map((secret: { id: string, status: string, created: string, expiresAt?: string }) => ({
+        secret_id: secret.id,
+        client_id: request.params.client_id,
+        status: secret.status,
+        created_at: secret.created,
+        expires_at: secret.expiresAt ?? null
+      }))
+
+      return reply.code(200).send({ secrets })
+    }
+  })
+
+  // POST /:client_id/secrets - Create new secret
+  fastify.route({
+    url: '/:client_id/secrets',
+    method: 'POST',
+    handler: async function (
+      request: FastifyRequest<{ Params: { client_id: string } }>,
+      reply: FastifyReply
+    ): Promise<FastifyReply> {
+      const headers = getHeaders(fastify.config.OKTA_API_TOKEN)
+
+      const response = await fastify.httpClient.post(
+        `oauth2/v1/clients/${request.params.client_id}/credentials/secrets`,
+        {},
+        { headers }
+      )
+
+      return reply.code(201).send({
+        secret_id: response.data.id,
+        client_id: request.params.client_id,
+        client_secret: response.data.client_secret,
+        created_at: response.data.created,
+        expires_at: response.data.expiresAt ?? null
+      })
+    }
+  })
+
+  // DELETE /:client_id/secrets/:secret_id - Delete specific secret
+  fastify.route({
+    url: '/:client_id/secrets/:secret_id',
+    method: 'DELETE',
+    handler: async function (
+      request: FastifyRequest<{ Params: { client_id: string, secret_id: string } }>,
+      reply: FastifyReply
+    ): Promise<FastifyReply> {
+      const headers = getHeaders(fastify.config.OKTA_API_TOKEN)
+      const { client_id: clientId, secret_id: secretId } = request.params
+
+      // Step 1: Deactivate the secret (Okta requires this before deletion)
+      try {
+        await fastify.httpClient.post(
+          `oauth2/v1/clients/${clientId}/credentials/secrets/${secretId}/lifecycle/deactivate`,
+          {},
+          { headers }
+        )
+      } catch (error: unknown) {
+        // Ignore if already inactive
+        const axiosError = error as { response?: { status?: number } }
+        if (axiosError.response?.status !== 400) {
+          throw error
+        }
+      }
+
+      // Step 2: Delete the secret
+      await fastify.httpClient.delete(
+        `oauth2/v1/clients/${clientId}/credentials/secrets/${secretId}`,
+        { headers }
+      )
+
+      return reply.code(204).send()
+    }
+  })
+
   next()
 }
 


### PR DESCRIPTION
This pull request introduces full support for managing OAuth2 client secrets via new API endpoints, updates the OpenAPI specification to document these features, and adds comprehensive documentation and test coverage. The changes are organized into three main themes: API feature additions, documentation updates, and test coverage.

**API Feature Additions:**

* Implemented three new endpoints in `handler.ts` for managing client secrets:
  - `GET /:client_id/secrets` to list all secrets for a client.
  - `POST /:client_id/secrets` to create a new secret.
  - `DELETE /:client_id/secrets/:secret_id` to deactivate (if required) and delete a specific secret.

* Updated the OpenAPI spec (`openapi/openapi.yaml`) to document the new endpoints, parameters, and response schemas for secret management, including metadata-only secret listing, creation with ID, and deletion. [[1]](diffhunk://#diff-5fa520d3bb34f9ae444cdbdf2b9eccff2361eb89a0cd3f4dba1e2e0fa9bba452R73-R117) [[2]](diffhunk://#diff-5fa520d3bb34f9ae444cdbdf2b9eccff2361eb89a0cd3f4dba1e2e0fa9bba452R129-R137) [[3]](diffhunk://#diff-5fa520d3bb34f9ae444cdbdf2b9eccff2361eb89a0cd3f4dba1e2e0fa9bba452R176-R187) [[4]](diffhunk://#diff-5fa520d3bb34f9ae444cdbdf2b9eccff2361eb89a0cd3f4dba1e2e0fa9bba452R410-R474)

**Documentation Updates:**

* Added a new `AGENTS.md` file with a comprehensive overview of the project, tech stack, architecture, boundaries, and usage instructions.
* Added `.github/copilot-instructions.md` and updated `CLAUDE.md` to provide clear contribution boundaries, quick references, and safety guidelines for contributors and Copilot. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R29) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R22)

**Test Coverage:**

* Added tests in `src/app.test.ts` to cover all new secret management endpoints, including success and failure scenarios for listing, creating, and deleting secrets (with correct API key enforcement and Okta-specific logic).

Other:

* Added a `.vscode/settings.json` file for consistent spell checking of Okta-specific terms.