### PR TITLE
feat(oas): add application owner to DCR payloads

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -209,6 +209,37 @@ components:
         calls to the IDP and verify its identity. Konnect doesn't store this
         data, if the secret is lost user should refresh the secret.
       example: "*8pNH%|(9PRH|r3q$#6!*z0B}jMbtQ]-"
+    DeveloperId:
+      type: string
+      format: uuid
+      description: |
+        ID of the developer whose action triggered the event. When the event is
+        triggered by a Konnect admin action rather than a developer action, this
+        is the null UUID `00000000-0000-0000-0000-000000000000`.
+
+        This identifies the *actor*, not the owner of the application. Use
+        `owner` to determine which entity the application belongs to.
+      example: 6a2b1f8c-1d0e-4c2f-9a3b-5e6d7c8f9a0b
+    Owner:
+      type: object
+      additionalProperties: false
+      description: |
+        The entity that owns the application. An application is owned by either
+        a single developer or a single team.
+      properties:
+        type:
+          type: string
+          enum:
+          - developer
+          - team
+        id:
+          type: string
+          format: uuid
+          description: |
+            ID of the owning developer or team, depending on `type`.
+      required:
+      - type
+      - id
     EventType:
       type: string
       enum:
@@ -250,8 +281,9 @@ components:
           type: string
           format: uuid
         developer_id:
-          type: string
-          format: uuid
+          $ref: '#/components/schemas/DeveloperId'
+        owner:
+          $ref: '#/components/schemas/Owner'
         auth_strategy_id:
           type: string
           format: uuid
@@ -267,6 +299,7 @@ components:
       - portal_id
       - organization_id
       - developer_id
+      - owner
       - auth_strategy_id
       - dcr_provider_id
     EventHookUpdateApplication:
@@ -367,8 +400,9 @@ components:
           type: string
           format: uuid
         developer_id:
-          type: string
-          format: uuid
+          $ref: '#/components/schemas/DeveloperId'
+        owner:
+          $ref: '#/components/schemas/Owner'
         auth_strategy_id:
           type: string
           format: uuid
@@ -385,6 +419,7 @@ components:
       - portal_id
       - organization_id
       - developer_id
+      - owner
       - auth_strategy_id
       - dcr_provider_id
     ApplicationResponse:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: DCR HTTP integration
-  version: 0.0.2
+  version: 0.1.0
   description: |
     Specification of the open api spec that should be implemented to
     support the konnect DCR http integration.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -46,7 +46,7 @@ paths:
         Rotates the secret of the application, making the current one unusable.
 
         **Note:** If more than one secret exisits, this endpoint will return an error.
-       
+
       responses:
         '200':
           $ref: '#/components/responses/NewSecret'

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -34,6 +34,7 @@ describe('dcr handlers', () => {
         portal_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2705',
         organization_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2706',
         developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707',
+        owner: { type: 'developer', id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707' },
         auth_strategy_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2708',
         dcr_provider_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2709'
       }
@@ -88,6 +89,7 @@ describe('dcr handlers', () => {
         portal_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2705',
         organization_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2706',
         developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707',
+        owner: { type: 'developer', id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707' },
         auth_strategy_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2708',
         dcr_provider_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2709'
       }
@@ -240,6 +242,7 @@ describe('dcr handlers', () => {
         portal_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
         organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
         developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707',
+        owner: { type: 'developer', id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707' },
         redirect_uris: [
           'https://example.com'
         ],
@@ -272,6 +275,7 @@ describe('dcr handlers', () => {
         portal_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
         organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
         developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707',
+        owner: { type: 'developer', id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707' },
         auth_strategy_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2708',
         dcr_provider_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2709'
       }
@@ -302,6 +306,7 @@ describe('dcr handlers', () => {
         portal_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
         organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
         developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707',
+        owner: { type: 'developer', id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707' },
         auth_strategy_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2708',
         dcr_provider_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2709'
       }
@@ -330,6 +335,7 @@ describe('dcr handlers', () => {
         portal_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
         organization_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
         developer_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707',
+        owner: { type: 'developer', id: '426ac0a7-aeb6-4043-a404-c4bfe24f2707' },
         redirect_uris: [
           'https://example.com'
         ],

--- a/src/schemas/ApplicationPayload.ts
+++ b/src/schemas/ApplicationPayload.ts
@@ -8,6 +8,10 @@ export interface ApplicationPayload {
   portal_id: string
   organization_id: string
   developer_id: string
+  owner: {
+    type: 'developer' | 'team'
+    id: string
+  }
   auth_strategy_id: string
   dcr_provider_id: string
 }
@@ -55,6 +59,21 @@ export const ApplicationPayloadSchema = {
       type: 'string',
       format: 'uuid'
     },
+    owner: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        type: {
+          type: 'string',
+          enum: ['developer', 'team']
+        },
+        id: {
+          type: 'string',
+          format: 'uuid'
+        }
+      },
+      required: ['type', 'id']
+    },
     auth_strategy_id: {
       type: 'string',
       format: 'uuid'
@@ -74,6 +93,7 @@ export const ApplicationPayloadSchema = {
     'portal_id',
     'organization_id',
     'developer_id',
+    'owner',
     'auth_strategy_id',
     'dcr_provider_id'
   ]

--- a/src/schemas/EventHook.ts
+++ b/src/schemas/EventHook.ts
@@ -16,6 +16,10 @@ export type EventHook = {
   portal_id: string
   organization_id: string
   developer_id: string
+  owner: {
+    type: 'developer' | 'team'
+    id: string
+  }
   auth_strategy_id: string
   dcr_provider_id: string
 } & (
@@ -71,6 +75,21 @@ export const EventHookSchema = {
     developer_id: {
       type: 'string'
     },
+    owner: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        type: {
+          type: 'string',
+          enum: ['developer', 'team']
+        },
+        id: {
+          type: 'string',
+          format: 'uuid'
+        }
+      },
+      required: ['type', 'id']
+    },
     auth_strategy_id: {
       type: 'string'
     },
@@ -95,6 +114,7 @@ export const EventHookSchema = {
       'portal_id',
       'organization_id',
       'developer_id',
+      'owner',
       'auth_strategy_id',
       'dcr_provider_id'
     ],


### PR DESCRIPTION
Konnect sends the application's owner as `owner: { type, id }` on the create payload and on every event hook, so a handler can attribute an application to the team or developer that owns it.

`developer_id` will continue to be included as the developer whose action triggered the event, or the null UUID when the event was triggered by a Konnect admin action. It identifies the actor, not the owner.